### PR TITLE
Update licensing guidelines

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,25 +47,9 @@
                 <li>Open source repositories should be hosted on <a href="https://github.com">GitHub.com</a> . Two-factor authentication will be required for all interactions with GitHub.</li>
                 <li>All repositories must be licensed <a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a>. If a different license is desired, please contact the IU Open Source Administrators at 
                     <a href="mailto:opensource@iu.edu">opensource@iu.edu</a> to discuss.</li>
-                <li>All repositories must have an appropriate LICENSE file containing the BSD 3 copyright notice and license text in the root of the repository.</li>
-                <li>Wherever practicable, all source files within the repository should include a comment block appropriate for the file type at or near the top of the file which contains a copyright notice and reference to the license.
-                    <ul>
-                        <li>The copyright notice should be written as follows:
-                            <div class="rvt-panel rvt-m-top-sm">
-                                <pre>Copyright (C) [year of first publication] The Trustees of Indiana University</pre>
-                            </div>
-                        </li>
-                        <li>For the reference to the license, you can either include the <a href="https://opensource.org/licenses/BSD-3-Clause">full BSD 3 license text</a> or the BSD 3 <a href="https://spdx.org/">SPDX</a> License Identifier</li>
-                        <li>For example, in a source code file that uses C-style block comments, you might include the following at the top of the file:
-                            <div class="rvt-panel rvt-m-top-sm">
-                <pre>/**
- * Copyright (C) [year of first publication] The Trustees of Indiana University
- * SPDX-License-Identifier: BSD-3-Clause
- */</pre>
-                            </div>
-                        </li>
-                    </ul>
-                </li>
+                <li>All repositories must have an appropriate <a href="LICENSE">LICENSE</a> file containing the BSD 3 copyright notice and license text in the root of the repository. The copyright year should be the year of first publication.</li>
+                <li>Adding a license header to source files within the repository is recommended but is not required.  For details why you may want to include them and instructions on how to do so may be found on the 
+                    <a href="licensing.html">Source File Licensing</a> page.</li>
                 <li>No non-public IU data may be stored in a repository. Please ensure you are familiar with the <a href="https://datamanagement.iu.edu/types-of-data/classifications.php">institutional data classifications</a>.</li>
                 <li>Take <strong>extra care</strong> to ensure no secrets (passwords, keys, etc.) are stored within a repository!</li>
                 <li>If secrets or non-public information makes its way into a repository, notify <a href="mailto:it-incident@iu.edu">it-incident@iu.edu</a> and <a href="mailto:opensource@iu.edu">opensource@iu.edu</a> <strong>immediately and 

--- a/licensing.html
+++ b/licensing.html
@@ -1,0 +1,82 @@
+<!--
+    Copyright (C) 2018 The Trustees of Indiana University
+    SPDX-License-Identifier: BSD-3-Clause
+-->
+<!DOCTYPE html>
+<html lang="en-US">
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link media="all" rel="stylesheet" href="./css/rivet.min.css">
+    <title>IU Open Source Program</title>
+</head>
+
+<body>
+    <header class="rvt-header" role="banner">
+        <a class="rvt-skip-link" href="#main-content">Skip to content</a>
+        <div class="rvt-header__trident">
+            <svg role="img" xmlns="http://www.w3.org/2000/svg" width="60" height="70" viewBox="0 0 60 70"
+                aria-labelledby="iu-logo">
+                <title id="iu-logo">Indiana University</title>
+                <rect width="60" height="70" fill="#900" />
+                <polygon
+                    points="35.96 18.44 35.96 21.84 38.52 21.84 38.52 40.51 33.41 40.51 33.41 15.9 35.96 15.9 35.96 12.5 24.04 12.5 24.04 15.9 26.58 15.9 26.58 40.51 21.48 40.51 21.48 21.84 24.04 21.84 24.04 18.44 12.09 18.44 12.09 21.84 14.65 21.84 14.65 43.79 18.72 48.15 26.58 48.15 26.58 53.26 24.04 53.26 24.04 57.5 35.96 57.5 35.96 53.26 33.41 53.26 33.41 48.15 40.93 48.15 45.33 43.79 45.33 21.84 47.91 21.84 47.91 18.44 35.96 18.44"
+                    fill="#fff" />
+            </svg>
+        </div>
+        <span class="rvt-header__title">
+            <a href="#0">Open Source Guidelines</a>
+        </span>
+    </header>
+    <main role="main" id="main-content">
+        <div class="rvt-container rvt-container--sophomore rvt-container--center">
+
+            <h1 class="rvt-ts-32 rvt-m-top-lg">Source File Licensing</h1>
+
+            <p>Individual source files within the repository MAY include a comment block at the top of the file which contains a
+            copyright notice and reference to the license. This comment block can help to convey
+            the license and copyright in the event that the source file gets separated from the repository. Here are some <a
+                href="https://github.com/indiana-university/copyright-notice-attacher/tree/master/notices">example comment
+                blocks</a> for many popular languages.</p>
+            <p>If your development environment / toolchain does not support the automatic application of copyright headers, consider using the
+            <a href="https://github.com/indiana-university/copyright-notice-attacher">copyright-notice-attacher</a> to apply the header to common source file types.</p>
+
+
+        </div>
+
+
+        <!-- **************************************************************
+            Start building here!
+        *************************************************************** -->
+
+    </main>
+    <footer class="rvt-footer m-top-xxl" role="contentinfo">
+        <div class="rvt-footer__copyright-lockup">
+            <div class=rvt-footer__trident>
+                <svg role="img" xmlns="http://www.w3.org/2000/svg" width="20" height="25" viewBox="0 0 20 25">
+                    <polygon
+                        points="13.33 3.32 13.33 5.21 14.76 5.21 14.76 15.64 11.9 15.64 11.9 1.9 13.33 1.9 13.33 0 6.67 0 6.67 1.9 8.09 1.9 8.09 15.64 5.24 15.64 5.24 5.21 6.67 5.21 6.67 3.32 0 3.32 0 5.21 1.43 5.21 1.43 17.47 3.7 19.91 8.09 19.91 8.09 22.76 6.67 22.76 6.67 25.13 13.33 25.13 13.33 22.76 11.9 22.76 11.9 19.91 16.1 19.91 18.56 17.47 18.56 5.21 20 5.21 20 3.32 13.33 3.32"
+                        fill="#900" />
+                </svg>
+            </div>
+            <p><a href="https://www.iu.edu/copyright/index.html">Copyright</a> &copy; 2017 The Trustees of <a
+                    href="https://www.iu.edu/">Indiana University</a></p>
+        </div>
+        <ul class="rvt-footer__aux-links">
+            <li class="rvt-footer__aux-item">
+                <!-- You can learn more about privacy policies and generate one
+                     for your site here:
+                     https://protect.iu.edu/online-safety/tools/privacy-notice/index.html -->
+                <a href="#0">Privacy Policy</a>
+            </li>
+            <li class="rvt-footer__aux-item">
+                <a href="https://accessibility.iu.edu/">Accessibility help</a>
+            </li>
+        </ul>
+    </footer>
+    <script src="./js/rivet.min.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
A few months ago James and I worked on tweaking the licensing guidelines. This PR puts those changes into effect. I created a separate `licensing.html` page with rationale for and examples of per-file copyright notices. I linked to this page from the body of the main document and tightened up the main document text.
